### PR TITLE
[2025.4.2] cf-tunnel-pi Release

### DIFF
--- a/cf-tunnel-pi/Dockerfile
+++ b/cf-tunnel-pi/Dockerfile
@@ -2,7 +2,7 @@ ARG ARCH=arm/v7
 FROM ubuntu:22.04 AS base
 
 # Set noninteractive mode to avoid tzdata and other prompts
-ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Set default command
 SHELL ["/bin/bash", "-c"]

--- a/cf-tunnel-pi/Dockerfile
+++ b/cf-tunnel-pi/Dockerfile
@@ -7,13 +7,21 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Set default command
 SHELL ["/bin/bash", "-c"]
 
-## Install cloudflared armhf
-RUN apt-get update && apt-get install -y wget dpkg && \
-    version="$(date +'%Y.%-m')" && \ 
-    wget --no-check-certificate "https://github.com/cloudflare/cloudflared/releases/download/${version}.0/cloudflared-linux-armhf.deb" && \
+## Install dependencies
+RUN apt-get update && apt-get install -y wget dpkg curl gawk grep && \
+    # Get the latest version of cloudflared
+    version=$(curl -s https://github.com/cloudflare/cloudflared/tags | \
+        awk -F'tags/' '{if (NF>1) print $2}' | \
+        awk -F'"' '{print $1}' | \
+        grep '\.tar\.gz' | \
+        awk -F'.tar.gz' '{print $1}' | \
+        sort -Vr | head -n1) && \
+    echo "Latest version: $version" && \
+    # Download the latest release for ARM architecture
+    wget --no-check-certificate "https://github.com/cloudflare/cloudflared/releases/download/${version}/cloudflared-linux-armhf.deb" && \
     dpkg -i cloudflared-linux-armhf.deb && \
     rm cloudflared-linux-armhf.deb
 
 ENTRYPOINT [ "cloudflared" ]
 
-## Tag update
+## Tag update & Re-engineering Dockerfile


### PR DESCRIPTION
[v2025.4.2] Stable release :

- Update Dockerfile logic 
- Change `ENV DEBIAN_FRONTEND=noninteractive` to `ARG DEBIAN_FRONTEND=noninteractive`
- Add lookup for latest image for cloudflare-armhf